### PR TITLE
Upgrade kotlin from 1.4.20 to 1.4.21

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -7,4 +7,4 @@
 
 version.it.unibo.alchemist=9.3.0-devej+a0050f05c
 
-version.kotlin=1.4.20
+version.kotlin=1.4.21


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.